### PR TITLE
csvimport.py: Don't blow up if some categories are empty

### DIFF
--- a/pynYNAB/scripts/csvimport.py
+++ b/pynYNAB/scripts/csvimport.py
@@ -140,7 +140,7 @@ def do_csvimport(args,client=None):
                 get_logger(args).error('Couldn''t find this account: %s' % args.accountname)
                 exit(-1)
 
-            if 'category' in schema.headers:
+            if result.category and 'category' in schema.headers:
                 entities_subcategory_id = getsubcategory(result.category).id
             else:
                 entities_subcategory_id = None


### PR DESCRIPTION
Use-case: I import tons of transactions from CSV; some of them have categories pre-populated, some don't.

With this change empty categories (ie. CSV rows where the category is the empty string) will not have a category set, same way as if the whole CSV had no category field.